### PR TITLE
Allow redirection from directories with nested content.

### DIFF
--- a/lib/nanoc-redirector.rb
+++ b/lib/nanoc-redirector.rb
@@ -17,10 +17,8 @@ module NanocRedirector
         redirects.each do |redirect|
           content = NanocRedirector.redirect_template(dest)
           dir = "output/#{redirect}"
-          unless File.directory?(dir)
-            FileUtils.mkdir_p(dir)
-            File.write("#{dir}/index.html", content)
-          end
+          FileUtils.mkdir_p(dir) unless File.directory?(dir)
+          File.write("#{dir}/index.html", content) unless File.exist? "#{dir}/index.html"
         end
       end
     end

--- a/lib/nanoc-redirector.rb
+++ b/lib/nanoc-redirector.rb
@@ -16,9 +16,10 @@ module NanocRedirector
       redirect_hash.values.each do |redirects|
         redirects.each do |redirect|
           content = NanocRedirector.redirect_template(dest)
-          dir = "output/#{redirect}"
+          dir = File.join("output", redirect)
+          redirect_path = File.join(dir, "index.html")
           FileUtils.mkdir_p(dir) unless File.directory?(dir)
-          File.write("#{dir}/index.html", content) unless File.exist? "#{dir}/index.html"
+          File.write(redirect_path, content) unless File.exist? redirect_path
         end
       end
     end

--- a/test/fixtures/content/redirect_from/existing-content.html
+++ b/test/fixtures/content/redirect_from/existing-content.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>
+Existing content
+</title>
+</head>
+
+<body>
+
+This file should not be removed by the redirector.
+
+</body>
+</html>
+

--- a/test/fixtures/content/redirect_from/existing-content.md
+++ b/test/fixtures/content/redirect_from/existing-content.md
@@ -1,0 +1,5 @@
+---
+title: Existing content
+---
+
+This file should not be removed by the redirector.

--- a/test/fixtures/content/redirect_from/from-nested-root.md
+++ b/test/fixtures/content/redirect_from/from-nested-root.md
@@ -1,6 +1,6 @@
 ---
 title: From nested root
-redirect_from: /nested/
+redirect_from: /redirect_from/nested/
 ---
 
 This article should be redirected from the nested root.

--- a/test/fixtures/content/redirect_from/from-nested-root.md
+++ b/test/fixtures/content/redirect_from/from-nested-root.md
@@ -1,0 +1,6 @@
+---
+title: From nested root
+redirect_from: /nested/
+---
+
+This article should be redirected from the nested root.

--- a/test/fixtures/content/redirect_from/nested/nested-article.md
+++ b/test/fixtures/content/redirect_from/nested/nested-article.md
@@ -1,0 +1,6 @@
+---
+title: Nested article
+---
+
+This article will create a subdirectory in `/nested/` that might foil redirecting.
+

--- a/test/fixtures/content/redirect_from/replaces-existing-content.md
+++ b/test/fixtures/content/redirect_from/replaces-existing-content.md
@@ -1,0 +1,6 @@
+---
+title: Replaces existing content
+redirect_from: /redirect_from/existing-content
+---
+
+This shouldn't clobber existing content.

--- a/test/redirect_from_test.rb
+++ b/test/redirect_from_test.rb
@@ -36,4 +36,15 @@ class RedirectFromTest < MiniTest::Test
       assert_includes output_file, 'redirect_from/array'
     end
   end
+
+  def test_it_does_not_clobber_existing_files
+    with_site(name: FIXTURES_DIR) do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compile
+
+      output_file = read_output_file('redirect_from', 'existing-content')
+      test_file = read_test_file('redirect_from', 'existing-content')
+      assert_equal output_file, test_file
+    end
+  end
 end

--- a/test/redirect_from_test.rb
+++ b/test/redirect_from_test.rb
@@ -47,4 +47,14 @@ class RedirectFromTest < MiniTest::Test
       assert_equal output_file, test_file
     end
   end
+
+  def test_it_allows_redirects_from_content_directory_indexes
+    with_site(name: FIXTURES_DIR) do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compile
+
+      nested_redirect_file = read_output_file('redirect_from', 'nested')
+      assert_includes nested_redirect_file 'redirect_from/from-nested-root'
+    end
+  end
 end

--- a/test/redirect_from_test.rb
+++ b/test/redirect_from_test.rb
@@ -54,7 +54,7 @@ class RedirectFromTest < MiniTest::Test
       site.compile
 
       nested_redirect_file = read_output_file('redirect_from', 'nested')
-      assert_includes nested_redirect_file 'redirect_from/from-nested-root'
+      assert_includes nested_redirect_file, 'redirect_from/from-nested-root'
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ class Minitest::Test
 end
 
 def test_output_file(*dir)
-  File.exists?(File.join('output', dir, 'index.html'))
+  File.exist?(File.join('output', dir, 'index.html'))
 end
 
 def read_output_file(*dir)


### PR DESCRIPTION
If a redirect_from entry targets a content location which still exists, the redirect will not be created because of the directory existence protection in lib/nanoc-redirector.rb:20. However, this implementation also prevents the creation of redirects from directories that have other content. Such as an `articles` directory. Before this it was not possible
to create redirects for directories that have existing content. This is good when that content is an `index.html` file which would be overwritten, but we should be able to redirect from the index of a directory that only exists with nested content.

cc @gjtorikian @lynnwallenstein
