### PR TITLE
Update Nanoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2
+  - 2.3
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module NanocRedirector
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/nanoc-redirector.gemspec
+++ b/nanoc-redirector.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'nanoc', '~> 4.3.0'
+  spec.add_runtime_dependency 'nanoc', '~> 4.9.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.8'


### PR DESCRIPTION
Motivation:
  - In order to update to Nanoc 4.9 we need to allow that version.