### PR TITLE
Relax Nanoc dependency

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module NanocRedirector
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/nanoc-redirector.gemspec
+++ b/nanoc-redirector.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'nanoc', '~> 4.9.0'
+  spec.add_runtime_dependency 'nanoc', '~> 4.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.8'


### PR DESCRIPTION
Let's relax the Nanoc dependency, so that this plugin
can be used with the recent versions of Nanoc.