### PR TITLE
Fix invalid HTML in redirect template

### DIFF
--- a/lib/nanoc-redirector.rb
+++ b/lib/nanoc-redirector.rb
@@ -38,6 +38,8 @@ module NanocRedirector
 <title>Redirecting...</title>
 <link rel=canonical href="#{item_url}">
 <meta http-equiv=refresh content="0; url=#{item_url}">
+</head>
+<body>
 <h1>Redirecting...</h1>
 <a href="#{item_url}">Click here if you are not redirected.</a>
 <script>location='#{item_url}'</script>


### PR DESCRIPTION
Bumped into this somewhat at random but the HTML generated here is missing the `</head><body>` tags.

I have little doubt most browsers would still manage to honor it... browsers can do amazing and terrible things with invalid HTML. 🤯